### PR TITLE
Don't duplicate the name attribute when cloning an input box

### DIFF
--- a/components/js/jquery.scrib-authority.js
+++ b/components/js/jquery.scrib-authority.js
@@ -144,7 +144,7 @@
 					for ( var attr, i = 0, attrs = $orig.get(0).attributes, length = attrs.length; i < length; i++ ) {
 						attr = attrs.item( i );
 
-						if ( 'class' !== attr.nodeName && 'id' !== attr.nodeName && 'type' !== attr.nodeName && 'style' !== attr.nodeName ) {
+						if ( 'name' !== attr.nodeName && 'class' !== attr.nodeName && 'id' !== attr.nodeName && 'type' !== attr.nodeName && 'style' !== attr.nodeName ) {
 							$entry.attr( attr.nodeName, attr.nodeValue );
 						}//end if
 					}//end for


### PR DESCRIPTION
This should fix the issue causing terms to disappear when saving authority records.

See GigaOM/legacy-pro#393
