### PR TITLE
Add HTML/RSS meta data when viewing a authority term

### DIFF
--- a/components/class-authority-posttype.php
+++ b/components/class-authority-posttype.php
@@ -51,7 +51,7 @@ class Authority_Posttype {
 	{
 		$authority = $this->queried_authority_data();
 
-		if ( $authority && ! is_wp_error( $authority->post ) && $authority->post->post_excerpt )
+		if ( $authority && ! is_wp_error( $authority->post ) && ! empty( $authority->post->post_excerpt ) )
 		{
 			echo '<meta name="description" content="' . esc_attr( $authority->post->post_excerpt ) . '">';
 		}//end if


### PR DESCRIPTION
HTML:
- adds the `<meta name="description">` element if an excerpt is available

RSS/RSS2:
- overrides the description element's contents to use the Authority Term's excerpt (when available)
- adds an `<image>` element to the RSS feed when a thumbnail is set on the Authority Term

See: GigaOM/gigaom#1841
