### PR TITLE
It's save_post

### DIFF
--- a/components/class-authority-posttype.php
+++ b/components/class-authority-posttype.php
@@ -31,7 +31,7 @@ class Authority_Posttype {
 		add_filter( 'post_type_link', array( $this, 'post_link' ), 11, 2 );
 		add_filter( 'scriblio_facet_taxonony_terms', array( $this, 'scriblio_facet_taxonony_terms' ) );
 
-		add_action( 'set_object_terms', array( $this , 'enforce_authority_on_object' ) );
+		add_action( 'save_post', array( $this , 'enforce_authority_on_object' ) );
 
 		if ( is_admin() )
 		{
@@ -710,16 +710,10 @@ class Authority_Posttype {
 		// add the alias and parent terms to the object
 		if ( count( $new_object_terms ))
 		{
-			// Turn the filter off so we don't infinite loop
-			remove_filter( 'set_object_terms', array( $this , 'enforce_authority_on_object' ) );
-
 			foreach( (array) $new_object_terms as $k => $v )
 			{
 				wp_set_object_terms( $object_id , $v , $k , TRUE );
 			}
-
-			// Activate filter again
-			add_action( 'set_object_terms', array( $this , 'enforce_authority_on_object' ) );
 
 			update_post_cache( $post );
 		}


### PR DESCRIPTION
Backng out the change from `save_post` to `set_object_terms` in 8130141c0a651dffc4157402ea2bd21eadc1da47 after @wluo identified and confirmed it as the cause of the problem we were seeing with tags disappearing.
