### PR TITLE
auto suggest fix

### DIFF
--- a/components/class-scriblio-authority-suggest.php
+++ b/components/class-scriblio-authority-suggest.php
@@ -17,8 +17,15 @@ class Scriblio_Authority_Suggest
 		add_rewrite_endpoint( $this->ep_name_suggest, EP_ALL );
 
 		add_filter( 'request', array( $this, 'request' ) );
-		
-		wp_localize_script( 'jquery-ui-core', 'scrib_authority_suggest', array( 'url' => home_url( "/{$this->ep_name_suggest}" ) ) );
+
+		if ( is_admin() )
+		{
+			wp_localize_script( 'jquery-ui-core', 'scrib_authority_suggest', array( 'url' => home_url( "/{$this->ep_name_suggest}" ) ) );
+		}
+		else
+		{
+			wp_localize_script( 'jquery', 'scrib_authority_suggest', array( 'url' => home_url( "/{$this->ep_name_suggest}" ) ) );
+		}
 	}//end init
 
 	public function add_query_var( $qvars )


### PR DESCRIPTION
have scrib_authority_suggest script depend on jquery-ui-core when we're in the admin dashboard, and set it to depend on jquery when we're not.

this fixes the missing auto-suggest on search's front page in WP 3.5 and still works around a 3.6 issue.
