### PR TITLE
Localize scripts later

### DIFF
--- a/components/class-scriblio-authority-suggest.php
+++ b/components/class-scriblio-authority-suggest.php
@@ -22,12 +22,11 @@ class Scriblio_Authority_Suggest
 		{
 			add_action( 'wp_ajax_scriblio_authority_suggestions', array( $this, 'get_suggestions' ) );
 			add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue_scripts' ) );
-		}
+		}//end if
 		else
 		{
-			wp_localize_script( 'jquery', 'scrib_authority_suggest', array( 'url' => home_url( "/{$this->ep_name_suggest}" ) ) );
 			add_action( 'wp_enqueue_scripts', array( $this, 'wp_enqueue_scripts' ) );
-		}
+		}//end else
 	}//end init
 
 	/**


### PR DESCRIPTION
the scrib_suggest variable was not being initialized on the dashboard, causing the authority page to lose it's JS functionality
