### PR TITLE
clean up spurious scriblio-authority-suggest endpoints

### DIFF
--- a/components/class-scriblio-authority-suggest.php
+++ b/components/class-scriblio-authority-suggest.php
@@ -14,7 +14,7 @@ class Scriblio_Authority_Suggest
 	 */
 	public function init()
 	{
-		add_rewrite_endpoint( $this->ep_name_suggest, EP_ALL );
+		add_rewrite_endpoint( $this->ep_name_suggest, EP_ROOT );
 
 		add_filter( 'request', array( $this, 'request' ) );
 


### PR DESCRIPTION
only add scriblio-authority-suggest endpoint to root urls instead of all urls

see http://github.com/GigaOM/legacy-pro/issues/2054
