### PR TITLE
To support requests for results cross-site, let's support JSONP

### DIFF
--- a/components/class-scriblio-authority-suggest.php
+++ b/components/class-scriblio-authority-suggest.php
@@ -76,7 +76,17 @@ class Scriblio_Authority_Suggest
 		$suggestions = $this->suggestions( $s, array(), $threshold );
 
 		header('Content-Type: application/json');
-		echo json_encode( $suggestions );
+
+		$json = json_encode( $suggestions );
+
+		if ( isset( $_GET['callback'] ) )
+		{
+			echo preg_replace( '/[^a-zA-Z0-9\._\-]/', '', $_GET['callback'] ) . '(' . $json . ');';
+		}//end if
+		else
+		{
+			echo $json;
+		}//end else
 		die;
 	}//end get_suggestions
 

--- a/components/js/jquery.scrib-authority.js
+++ b/components/js/jquery.scrib-authority.js
@@ -53,6 +53,10 @@
 	var methods = {
 		init: function( params ) {
 
+			if ( params.url ) {
+				scrib_authority_suggest.url = params.url;
+			}
+
 			// fix the ajax url
 			if ( 'https:' === window.location.protocol ) {
 				scrib_authority_suggest.url = scrib_authority_suggest.url.replace( 'http:', 'https:' );
@@ -504,9 +508,9 @@
 				return;
 			}//end if
 
-			var xhr = $.getJSON( scrib_authority_suggest.url, params );
+			var xhr = $.getJSON( scrib_authority_suggest.url + '?callback=?', params );
 
-			$.when( xhr ).done( function( data ) {
+			xhr.done( function( data ) {
 				if ( typeof data != 'undefined' ) {
 					$root.ScribAuthority('results', data);
 					methods.show_results( $root );


### PR DESCRIPTION
Without this change, the results can only be provided from the same site the search is executed on.
