### PR TITLE
Check whether the params object is undefined or not to prevent js error

### DIFF
--- a/components/js/jquery.scrib-authority.js
+++ b/components/js/jquery.scrib-authority.js
@@ -53,7 +53,7 @@
 	var methods = {
 		init: function( params ) {
 
-			if ( params.url ) {
+			if ( 'undefined' != typeof params && 'undefined' != typeof params.url ) {
 				scrib_authority_suggest.url = params.url;
 			}
 


### PR DESCRIPTION
See: https://github.com/GigaOM/legacy-pro/issues/2997
