### PR TITLE
Support URLs with a query string

### DIFF
--- a/components/js/jquery.scrib-authority.js
+++ b/components/js/jquery.scrib-authority.js
@@ -511,6 +511,8 @@
 			}//end if
 
 			var url = scrib_authority_suggest.url;
+
+			// we need to handle both pretty and admin-ajax URLs - so ? may or may not be present
 			if ( url.indexOf( '?' ) ) {
 				url += '&callback=?';
 			} else {


### PR DESCRIPTION
This was only supporting the front-end EP urls

See: https://github.com/GigaOM/legacy-pro/issues/2997
