### PR TITLE
Added javascript to pin autosuggest to search-box

### DIFF
--- a/components/js/jquery.scrib-authority.js
+++ b/components/js/jquery.scrib-authority.js
@@ -158,7 +158,7 @@
 				$entry_container.css('top', function() {
 					var margin = $( selectors.entry ).css( 'margin-bottom' ).replace("px", "");
 
-					return parseInt( margin ) * -1;
+					return parseInt( margin, 10 ) * -1;
 				});
 
 				$root.append('<div class="' + selector + '-clearfix"/>');


### PR DESCRIPTION
Applies to https://github.com/GigaOM/legacy-pro/issues/2985 

ensure the autosuggest is pinned to the bottom of a search-box.

Styles will be in the child theme: https://github.com/GigaOM/gigaom/issues/4273
