### PR TITLE
fixed a PHP warning

### DIFF
--- a/components/class-authority-posttype.php
+++ b/components/class-authority-posttype.php
@@ -220,7 +220,7 @@ class Authority_Posttype {
 
 		if ( FALSE !== ( $return = wp_cache_get( $term->term_taxonomy_id, 'scrib_authority_ttid_'. $this->version ) ) )
 		{
-			if ( -1 == $return )
+			if ( is_int( $return ) && -1 == $return )
 			{
 				return FALSE; // convert our "no auth term" token to a valid return value
 			}


### PR DESCRIPTION
there's an implicit cast from `stdClass` to `int` that was causing the warning.

see https://github.com/misterbisson/scriblio-authority/issues/78
