### PR TITLE
Revert "Reformat search suggest so tags don't overflow taxonomies"

### DIFF
--- a/components/css/scrib-authority.structure.css
+++ b/components/css/scrib-authority.structure.css
@@ -57,11 +57,12 @@
 	border: 1px solid #ccc;
 	display: inline-block;
 	float: left;
-	margin: 0 5px .2rem 0;
+	margin: 0 5px 5px 0;
   overflow: hidden;
-	padding: .5rem 32px .5rem .5rem;
+	padding: 0;
   position: relative;
   text-decoration: none;
+  white-space: nowrap;
 
 	-webkit-border-radius: 3px;
 	-moz-border-radius: 3px;
@@ -100,34 +101,24 @@
 }
 
 .scrib-authority-box .taxonomy {
-	background: #fefefe;
-	-webkit-border-radius: 4px;
-	-moz-border-radius: 4px;
-	border-radius: 4px;
+	border-right: 1px solid #ccc;
 	color: #999;
 	cursor: pointer;
-	font-size: .75rem;
-	padding: 0 .25rem;
 }
 
 .scrib-authority-box .scrib-authority-box-results .taxonomy {
-	background: #f6f6f6;
+	float: right;
+	border-left: 1px dotted #eee;
+	border-right: none;
 }
 
 .scrib-authority-box .term {
-	display: block;
-	padding-left: 0;
 }
 
 .scrib-authority-box .close {
 	border-left: 1px solid #ccc;
-	bottom: 0;
 	color: #999;
 	cursor: pointer;
-	padding-top: 1.25rem;
-	position: absolute;
-	right: 0;
-	top: 0;
 	text-align: center;
 }
 
@@ -181,10 +172,6 @@
 	padding: 3px;
 }
 
-.scrib-authority-box .scrib-authority-box-results .scrib-authority-box-item {
-	cursor: pointer;
-}
-
 .scrib-authority-box .scrib-authority-box-results .scrib-authority-box-no-results {
 	color: #999;
 }
@@ -225,16 +212,15 @@
 
 .scrib-authority-box .scrib-authority-box-results .scrib-authority-box-item.focus .taxonomy,
 .scrib-authority-box .scrib-authority-box-results .scrib-authority-box-item:hover .taxonomy {
-	color: #999;
-	border: 0;
-
-	-webkit-text-shadow: 0 -1px transparent;
-	-moz-text-shadow: 0 -1px 0 transparent;
-	-o-text-shadow: 0 -1px 0 transparent;
-	text-shadow: 0 -1px 0 transparent;
+	color: #d1f1ff;
+	border-color: #0789c1;
 }
 
 .scrib-authority-box .scrib-authority-box-results .scrib-authority-box-item.focus,
 .scrib-authority-box .scrib-authority-box-results .scrib-authority-box-item:hover {
 	background: #0d9fe2;
+}
+
+.scrib-authority-box .scrib-authority-box-results .scrib-authority-box-item .taxonomy:hover {
+	background: inherit;
 }

--- a/components/js/jquery.scrib-authority.js
+++ b/components/js/jquery.scrib-authority.js
@@ -374,7 +374,7 @@
 
 					$item.append( $taxonomy );
 				} else {
-					$item.prepend( $('<span class="' + key + '" />').html( data_value ) );
+					$item.append( $('<span class="' + key + '" />').html( data_value ) );
 				}//end if
 			});
 
@@ -628,8 +628,7 @@
 					var $taxonomy = $('<span class="taxonomy">' + value.labels.singular_name + '</span>');
 					$taxonomy.data('taxonomy', value);
 					$item.append( $taxonomy );
-					$item.prepend( '<span class="term"></span>' );
-					$item.append( '<span class="close">x</span>' );
+					$item.append( '<span class="term"></span><span class="close">x</span>' );
 					$categories.append( $item );
 				});
 			}//end else


### PR DESCRIPTION
Reverts misterbisson/scriblio-authority#75

The PR specifically stated:

> This isn't necessarily meant to be merged in as-is, but instead spur a conversation about the way these things could look.

...yet I merged it anyway. My mistake.

Was originally per https://github.com/GigaOM/legacy-pro/issues/3998 , but maybe affects https://github.com/GigaOM/legacy-pro/issues/4101 .
