### PR TITLE
restore the filter hook callback's function signature from Facet_Taxonomy

### DIFF
--- a/components/class-authority-posttype.php
+++ b/components/class-authority-posttype.php
@@ -1069,7 +1069,7 @@ class Authority_Posttype {
 	} // END scriblio_facet_taxonomy_terms
 
 	/**
-	 * hook to scriblio's 'scriblio_facet_taxonomy_terms' action from
+	 * hook to scriblio's 'scriblio_searchword_to_taxonomy_terms' action from
 	 * scriblio.
 	 *
 	 * @param array $terms list of term objects to filter


### PR DESCRIPTION
and hook to the new one from Facet_Searchword.

as part of https://github.com/GigaOM/legacy-pro/issues/3995
