### PR TITLE
correctly test the type of cached authority records set to -1

### DIFF
--- a/components/class-authority-posttype.php
+++ b/components/class-authority-posttype.php
@@ -221,7 +221,7 @@ class Authority_Posttype {
 
 		if ( FALSE !== ( $return = wp_cache_get( $term->term_taxonomy_id, 'scrib_authority_ttid_'. $this->version ) ) )
 		{
-			if ( is_int( $return ) && -1 == $return )
+			if ( is_numeric( $return ) && -1 == $return )
 			{
 				return FALSE; // convert our "no auth term" token to a valid return value
 			}


### PR DESCRIPTION
they're stored as strings, not ints. this fixes lots of PHP warnings and a fatal when the latest code is run with older cached authority records.

related to https://github.com/GigaOM/legacy-pro/issues/3995

maybe also related to https://github.com/GigaOM/legacy-pro/issues/4123 and https://github.com/GigaOM/legacy-pro/issues/4124
