### PR TITLE
Support scrolling on scriblio search results on Android.

### DIFF
--- a/components/js/jquery.scrib-authority.js
+++ b/components/js/jquery.scrib-authority.js
@@ -193,6 +193,8 @@
 				});
 
 				$root.on( 'touchend.scrib-authority-box', selectors.results + ' ' + selectors.item, function( e ) {
+					e.preventDefault();
+
 					// if there isn't a touch start item, bail
 					if ( ! $root.$current_touch_item ) {
 						$root.$current_touch_item = null;


### PR DESCRIPTION
Android seemed to be interpreting the touchend and firing the click on the anchor tag rather than letting us determine if it was a click or not.

See: https://github.com/GigaOM/legacy-pro/issues/4160
