### PR TITLE
do not call simplify_taxonomy_for_json() with a NULL taxonomy object

### DIFF
--- a/components/class-authority-posttype.php
+++ b/components/class-authority-posttype.php
@@ -452,7 +452,10 @@ class Authority_Posttype {
 					continue;
 				}//end if
 
-				$taxonomy = get_taxonomy( $taxonomy );
+				if ( ! $taxonomy = get_taxonomy( $taxonomy ) )
+				{
+					continue;
+				}
 
 				$taxonomies[ $key ] = $this->simplify_taxonomy_for_json( $taxonomy );
 			}//end foreach


### PR DESCRIPTION
discovered while working on https://github.com/GigaOM/legacy-pro/issues/4125
