### PR TITLE
Pass term slug to push instead of name

### DIFF
--- a/components/js/jquery.scrib-authority.js
+++ b/components/js/jquery.scrib-authority.js
@@ -477,6 +477,7 @@
 				if( 'data' === key ) {
 					$.each( data_value, function( data_key, key_value ) {
 						$item.data( data_key, key_value );
+						$item.attr( 'data-' + data_key, key_value );
 					});
 				} else if ( 'taxonomy' === key ) {
 					var $taxonomy = $( '<span/>', {
@@ -711,7 +712,7 @@
 
 				var row = {
 					taxonomy: $term.find('.taxonomy').data('taxonomy'),
-					term: $term.find('.term').html()
+					term: $term.data('slug')
 				};
 
 				data.push( row );


### PR DESCRIPTION
- We were eroneously passing the term (i.e. name) sometimes instead of the actual slug.  
	- This meant you could not set terms that had slugs that didn't match their name failed.

https://github.com/GigaOM/legacy-pro/issues/2075