### PR TITLE
A small fix to how the slugs were being treated.

### DIFF
--- a/components/js/jquery.scrib-authority.js
+++ b/components/js/jquery.scrib-authority.js
@@ -493,7 +493,7 @@
 					$.each( data_value, function( data_key, key_value ) {
 						$item.data( data_key, key_value );
 
-						// We need slug availble to us later on.
+						// We need the slug available to us later on.
 						if ( 'term' === data_key ) {
 							$item.attr( 'data-' + data_key, key_value );
 							var tax_term = key_value.split( ':' );

--- a/components/js/jquery.scrib-authority.js
+++ b/components/js/jquery.scrib-authority.js
@@ -477,7 +477,13 @@
 				if( 'data' === key ) {
 					$.each( data_value, function( data_key, key_value ) {
 						$item.data( data_key, key_value );
-						$item.attr( 'data-' + data_key, key_value );
+
+						// We need slug availble to us later on.
+						if ( 'term' === data_key ) {
+							$item.attr( 'data-' + data_key, key_value );
+							var tax_term = key_value.split( ':' );
+							$item.attr( 'data-slug', tax_term[1] );
+						}
 					});
 				} else if ( 'taxonomy' === key ) {
 					var $taxonomy = $( '<span/>', {

--- a/components/js/jquery.scrib-authority.js
+++ b/components/js/jquery.scrib-authority.js
@@ -410,9 +410,24 @@
 						return false;
 					}//end if
 
+					// if a valid char is pressed
 					if ( 48 <= code || 8 === code || 46 === code ) {
-						// if a valid char is pressed
-						$root.find( selectors.newitem ).find('.term').html( val );
+						var $custom = $root.find( selectors.newitem );
+
+						// loop over the custom "results" and set their term values and associated data attributes
+						$custom.each( function() {
+							var $el = $( this );
+
+							// make a slug-friendly version of the value entered by the user
+							var clean_val = val.toLowerCase();
+							clean_val = clean_val.replace( /[^a-z0-9\-\_ ]/g, ' ' );
+							clean_val = clean_val.replace( / +/g, '-' );
+
+							$el.find( '.term' ).html( val );
+							$el.attr( 'data-term', $el.find( '.taxonomy' ).data( 'taxonomy' ) + ':' + clean_val );
+							$el.attr( 'data-slug', clean_val );
+						});
+
 						if( 0 === $.trim( $(this).val() ).length ) {
 							$root.closest( 'form' ).removeClass( 'has-text' );
 							$root.find( selectors.results ).removeClass( 'has-results no-results' );


### PR DESCRIPTION
- Sometimes the slug value isn't there, so we'll generate it from the term value instead (which has the slug as one of it's parts)
- The custom (i.e. non existing terms) weren't including the data values (term/slug) we needed to properly add them to a record.
